### PR TITLE
fix instruction for adding specific meteor package

### DIFF
--- a/tools/cli/commands-packages.js
+++ b/tools/cli/commands-packages.js
@@ -1200,7 +1200,7 @@ main.registerCommand({
       Console.command("'meteor update'"), "to try to update those",
       "packages to their latest versions. If your packages cannot be",
       "updated further, try typing",
-      Console.command("`meteor add <package>@<newVersion>`"),
+      Console.command("`meteor add <package>@=<newVersion>`"),
       "to see more information.",
       Console.options({ bulletPoint: "* " }));
   }


### PR DESCRIPTION
Hi MDG, 
while trying to specify a specific version for the materialize:materialize package my team and I realised the instructions from the print out for specifying a specific version of a meteor package is slightly off.

Instead of `meteor add <package>@<newVersion>` it should be `meteor add <package>@=<newVersion>` with a `=` symbol.